### PR TITLE
Changed support libraries version to 22.2.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,6 +21,6 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:22.2.0'
-    compile 'com.android.support:design:22.2.0'
+    compile 'com.android.support:appcompat-v7:22.2.1'
+    compile 'com.android.support:design:22.2.1'
 }


### PR DESCRIPTION
Hi,
I was following your tutorial and I found some unexpected behavior around `step 9` when you explain `enterAlwaysCollapsed` flag.
I found out it was support library bug which is now fixed in 22.2.1 
